### PR TITLE
Fix: Info icon in PvoTNavBar renders oval instead of circular

### DIFF
--- a/design-system/src/main/java/com/prauga/pvot/designsystem/components/navigation/PvotNavBar.kt
+++ b/design-system/src/main/java/com/prauga/pvot/designsystem/components/navigation/PvotNavBar.kt
@@ -5,6 +5,8 @@ package com.prauga.pvot.designsystem.components.navigation
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -74,7 +76,8 @@ fun PvotNavBar(
                 modifier = Modifier
                     .barWidthModifier(sizes)
                     .height(sizes.barHeight)
-                    .padding(horizontal = sizes.contentPaddingHorizontal),
+                    .padding(horizontal = sizes.contentPaddingHorizontal)
+                    .horizontalScroll(rememberScrollState()),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(
                     sizes.itemSpacing,


### PR DESCRIPTION
This PR fixes the incorrect oval rendering of the info icon in the PvoTNavBar, ensuring it appears circular and consistent with the other navigation icons.
Fixes: #20 
![a](https://github.com/user-attachments/assets/50007976-88b0-4430-b443-e47e4612969b)
